### PR TITLE
feat: Add --no-cache to Docker build for diagnostics

### DIFF
--- a/UltimateComfy.sh
+++ b/UltimateComfy.sh
@@ -86,8 +86,9 @@ build_comfyui_image() {
     DOCKER_BUILD_LOG_FILE="${DOCKER_CONFIG_ACTUAL_PATH}/docker_build_$(date +%Y%m%d_%H%M%S).log"
     log_info "Docker build output will be logged to: ${DOCKER_BUILD_LOG_FILE}"
 
+    log_warn "Attempting a --no-cache build for diagnostics." # Inform the user
     # Execute docker build and tee output to log file and screen
-    docker build -t "$COMFYUI_IMAGE_NAME" \
+    docker build --no-cache -t "$COMFYUI_IMAGE_NAME" \
         --build-arg "$build_arg_devel_str" \
         "$DOCKER_CONFIG_ACTUAL_PATH" 2>&1 | tee "${DOCKER_BUILD_LOG_FILE}"
 


### PR DESCRIPTION
I've temporarily added the --no-cache flag to the `docker build` command in the `build_comfyui_image` function of `UltimateComfy.sh`. This is to ensure fresh execution of all build steps, particularly for diagnosing the ComfyUI-Manager installation, by preventing the use of cached layers.

A warning message is included to inform you that the build will take longer.