### PR TITLE
fix: Modify dialog call to redirect stderr to /dev/tty

### DIFF
--- a/UltimateComfy.sh
+++ b/UltimateComfy.sh
@@ -615,7 +615,8 @@ Choose an option:" \
                 "3" "Last ned/Administrer Modeller" \
                 "4" "Start ComfyUI Docker Container(e)" \
                 "5" "Stopp ComfyUI Docker Container(e)" \
-                "6" "Avslutt")
+                "6" "Avslutt" \
+                2>/dev/tty) # Added redirection here
 
             local dialog_exit_status=$?
             script_log "DEBUG: dialog command finished. main_choice='$main_choice', dialog_exit_status='$dialog_exit_status'"


### PR DESCRIPTION
Adjusts the \`dialog\` command within the \`main_menu\` function to explicitly redirect its standard error output to \`/dev/tty\` (using \`2>/dev/tty\`).

This is intended to fix an issue where \`dialog\` was exiting with status 255, possibly due to problems rendering its UI when stderr was not explicitly directed to a terminal. The standard output, containing the menu choice, is still captured by command substitution.