### PR TITLE
Fix: Install git if missing before cloning ComfyUI-Manager

### DIFF
--- a/UltimateComfy.sh
+++ b/UltimateComfy.sh
@@ -359,6 +359,21 @@ install_comfyui_manager_on_host() {
         return 1
     fi
 
+    # Check for git installation
+    if ! command -v git &> /dev/null; then
+        log_warn "git not found. Attempting to install..."
+        if sudo apt update && sudo apt install -y git; then
+            log_success "git installed successfully."
+            if ! command -v git &> /dev/null; then
+                log_error "git installation was reported as successful, but 'git' command is still not found. Please install git manually and try again."
+                return 1
+            fi
+        else
+            log_error "Failed to install git. Please install git manually and try again."
+            return 1
+        fi
+    fi
+
     log_info "Cloning ComfyUI-Manager to $manager_dir..."
     if git clone https://github.com/ltdrdata/ComfyUI-Manager.git "$manager_dir"; then
         log_success "ComfyUI-Manager cloned successfully to $manager_dir."


### PR DESCRIPTION
The `install_comfyui_manager_on_host` function in `UltimateComfy.sh` was modified to check for the `git` command before attempting to clone the ComfyUI-Manager repository.

If `git` is not found, the script will now:
1. Inform you that `git` is missing and an installation will be attempted.
2. Run `sudo apt update && sudo apt install -y git` to install `git`.
3. Verify if `git` was installed successfully.
4. If installation fails, an error message is displayed, and the cloning process is skipped.
5. If `git` is present (either initially or after installation), the script proceeds with cloning ComfyUI-Manager.

This change addresses an issue where the script would fail if `git` was not installed on the host system, providing a more robust setup experience.