### PR TITLE
Fix: Use sudo to remove ComfyUI-Manager directory

### DIFF
--- a/UltimateComfy.sh
+++ b/UltimateComfy.sh
@@ -336,8 +336,9 @@ install_comfyui_manager_on_host() {
         read -r -p "ComfyUI-Manager already exists at $manager_dir. Reinstall? (ja/nei): " reinstall_choice </dev/tty
         if [[ "$reinstall_choice" =~ ^[Jj][Aa]$ ]]; then
             log_info "Removing existing ComfyUI-Manager for reinstall..."
-            if ! rm -rf "$manager_dir"; then
-                log_error "Failed to remove existing ComfyUI-Manager directory. Please check permissions."
+            log_info "Attempting to remove with sudo due to potential permission issues..."
+            if ! sudo rm -rf "$manager_dir"; then
+                log_error "Failed to remove existing ComfyUI-Manager directory. Please check permissions and sudo access."
                 return 1
             fi
             log_success "Existing ComfyUI-Manager removed."


### PR DESCRIPTION
I modified the `install_comfyui_manager_on_host` function in `UltimateComfy.sh` to use `sudo rm -rf` when removing an existing ComfyUI-Manager directory during reinstall.

This change addresses 'Permission denied' errors that could occur if files within the ComfyUI-Manager directory (e.g., __pycache__ files) were owned by a different user (like root or the Docker container user).

An informational log message was also added to notify you that sudo is being used for this operation.