### PR TITLE
Fix: Correct syntax error in model_downloader.sh

### DIFF
--- a/model_downloader.sh
+++ b/model_downloader.sh
@@ -209,8 +209,6 @@ md_find_and_select_comfyui_path() {
 }
 
 md_get_links_from_url() {
-
-md_get_links_from_url() {
     script_log "DEBUG: ENTERING md_get_links_from_url (model_downloader.sh) for URL: $1"
     local url="$1"
     # Added timeout and error resilience for curl


### PR DESCRIPTION
Removes a duplicated function definition for `md_get_links_from_url` which was causing an "unexpected end of file" error.