### PR TITLE
Here's a summary of the changes I've made:

### DIFF
--- a/auto_download_service.sh
+++ b/auto_download_service.sh
@@ -188,6 +188,15 @@ download_node() {
         script_log "ERROR: Failed to create top-level directory for node $node_name at $target_node_top_level_dir"
         return 1
     fi
+    # Verify directory existence immediately after claimed successful creation
+    if [ ! -d "$target_node_top_level_dir" ]; then
+        script_log "CRITICAL_ERROR: Top-level node directory $target_node_top_level_dir was NOT CREATED or is not a directory, even though mkdir -p command reported success."
+        script_log "DEBUG: Listing contents of parent directory $(dirname "$target_node_top_level_dir"):"
+        ls -lA "$(dirname "$target_node_top_level_dir")"
+        return 1
+    else
+        log_info "VERIFIED: Top-level node directory $target_node_top_level_dir exists."
+    fi
 
     log_info "Starting recursive download for node $node_name into $target_node_top_level_dir"
     # Initial call: current_server_relative_path is empty,


### PR DESCRIPTION
I've updated `auto_download_service.sh` to add a specific verification step. This happens right after I try to create the main directory for a custom node within the `download_node` function.

Now, after I attempt to create the directory, the script checks if it actually exists and is a directory. If this check doesn't pass, I'll log a critical error, show you what's in the parent directory, and stop trying to download that particular node.

This update should help us figure out why the main folder for a custom node sometimes isn't created correctly, which then stops further files from being downloaded into it.