### PR TITLE
fix: Use python3 -m pip and document host dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ The script aims to streamline the ComfyUI experience, especially for users who p
 
 The `UltimateComfy.sh` setup now includes an automated background service (`auto_download_service.sh`) designed to keep your ComfyUI assets up-to-date.
 
+**Host Prerequisites:**
+-   For the service to automatically install Python dependencies for custom nodes (from `requirements.txt` files), `python3` and `python3-pip` must be installed and available in the PATH on the host system where `auto_download_service.sh` runs. If these are not present, `git clone` operations will still complete, but dependency installation will fail (and be retried on subsequent checks if the node isn't marked as 'processed').
+
 **Functionality:**
 -   **Automatic Updates:** The service runs in the background when you start ComfyUI using the generated `start_comfyui.sh` script. It polls a pre-configured server every 10 seconds.
 -   **Custom Nodes:**

--- a/auto_download_service.sh
+++ b/auto_download_service.sh
@@ -245,7 +245,7 @@ install_node_dependencies() {
     fi
 
     log_info "Installing dependencies from $requirements_file..."
-    pip install -r requirements.txt
+    python3 -m pip install -r requirements.txt
     local pip_exit_code=$?
 
     if [ $pip_exit_code -eq 0 ]; then


### PR DESCRIPTION
Updates `auto_download_service.sh` to use `python3 -m pip` for installing custom node dependencies. This is more robust than relying on `pip` alone being in the PATH and correctly aliased.

Updates `README.md` to include a 'Host Prerequisites' section under 'Auto-Download Service', informing you that `python3` and `python3-pip` are required on the host system for the service to install dependencies for custom nodes.

This addresses the "pip: command not found" error when the service runs on a host where `pip` is not directly in the execution PATH or correctly linked to Python 3's pip.