### PR TITLE
Fix: Ensure auto_download_service.sh has execute permissions

### DIFF
--- a/auto_download_service.sh
+++ b/auto_download_service.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+chmod u+x "$0"
 
 # Source utility scripts
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)


### PR DESCRIPTION
Adds a `chmod u+x "$0"` command at the beginning of the `auto_download_service.sh` script.

This change addresses an issue where the script could fail to run via `nohup` due to missing execute permissions for you when invoking it. By adding this command, the script attempts to grant itself execute permission for the owner, which should resolve the "Permission denied" error from nohup, assuming you have the necessary rights to modify
the script's permissions.