### PR TITLE
Fix: Correct mismatched quote in final echo of docker exec block

### DIFF
--- a/fix_custom_node_deps.sh
+++ b/fix_custom_node_deps.sh
@@ -30,7 +30,6 @@ docker exec "$CONTAINER_NAME" /bin/bash -c '
         fi
     done
 
-
     echo "--- Installerer spesifikke tilleggspakker ---"
     pip install --upgrade huggingface_hub diffusers
     pip install opencv-python-headless
@@ -39,8 +38,7 @@ docker exec "$CONTAINER_NAME" /bin/bash -c '
     pip install py-cpuinfo
     pip install pynvml
 
-
-    echo "Alle avhengigheter er nå sjekket og installert.'"
+    echo "Alle avhengigheter er nå sjekket og installert."
 '
 
 echo ""


### PR DESCRIPTION
This commit fixes a mismatched quote in the last `echo` command within the `docker exec` block in `fix_custom_node_deps.sh`. The command was `echo "Alle avhengigheter er nå sjekket og installert.'"` (double quote start, single quote end), which caused an "unexpected EOF while looking for matching `"'`" error.

The trailing single quote has been changed to a double quote to match the opening one, resolving the syntax error.