### PR TITLE
Fix: Remove set -e from docker exec block to ensure all installs run

### DIFF
--- a/fix_custom_node_deps.sh
+++ b/fix_custom_node_deps.sh
@@ -12,7 +12,6 @@ echo "Dette er en utvidet prosess og kan ta flere minutter. Vær tålmodig."
 # Kjører et robust installasjonsscript non-interaktivt inne i containeren.
 # Dette scriptet kjører FØRST Managerens verktøy, og DERETTER en manuell sjekk for å fange alt det overser.
 docker exec "$CONTAINER_NAME" /bin/bash -c '
-    set -e # Avslutt hvis en kommando feiler
 
     echo "--- Kjører ComfyUI-Manager sin restore-funksjon (første pass)..."
     # Navigate to ComfyUI directory and run the manager script


### PR DESCRIPTION
This commit removes the `set -e` command from the beginning of the script executed within the `docker exec` block in
`fix_custom_node_deps.sh`.

The purpose of this change is to ensure that all commands within this block, particularly the specific `pip install` commands for packages like `huggingface_hub`, `diffusers`, etc., are attempted even if previous commands (e.g., `restore-dependencies` or installations from `requirements.txt` files) fail. This addresses your feedback that these specific package installations were not occurring, likely due to premature script termination caused by `set -e`.