### PR TITLE
Fix: Update CUDA versions for Docker image generation

### DIFF
--- a/docker_setup.sh
+++ b/docker_setup.sh
@@ -14,8 +14,8 @@ SCRIPTS_DIR_NAME="scripts"
 COMFYUI_IMAGE_NAME="comfyui-app" # Default, can be overridden by main script if needed
 
 # Definer DEVEL image tag-delen her for klarhet
-DOCKER_CUDA_DEVEL_TAG="12.4.1-cudnn-devel-ubuntu22.04"
-# RUNTIME image tag er nå HARDKODET i Dockerfile-genereringen som "12.4.1-cudnn-runtime-ubuntu22.04"
+DOCKER_CUDA_DEVEL_TAG="12.8.1-cudnn-devel-ubuntu22.04"
+# RUNTIME image tag er nå HARDKODET i Dockerfile-genereringen som "12.8.1-cudnn-runtime-ubuntu22.04"
 
 # Dynamisk satte stier (will be set by initialize_docker_paths)
 DOCKER_CONFIG_ACTUAL_PATH=""
@@ -75,7 +75,7 @@ build_comfyui_image() {
     script_log "DEBUG FØR BUILD (Original DEVEL): DOCKER_CUDA_DEVEL_TAG er satt til: [$DOCKER_CUDA_DEVEL_TAG]"
     script_log "DEBUG FØR BUILD (Renset DEVEL): clean_devel_tag er satt til: [$clean_devel_tag]"
     log_info "Bruker devel tag (via build-arg): $clean_devel_tag"
-    log_info "Runtime tag er hardkodet i Dockerfile som: 12.4.1-cudnn-runtime-ubuntu22.04"
+    log_info "Runtime tag er hardkodet i Dockerfile som: 12.8.1-cudnn-runtime-ubuntu22.04"
     log_info "Dette kan ta en stund."
 
     local build_arg_devel_str
@@ -184,7 +184,7 @@ perform_docker_initial_setup() {
     printf 'RUN %s\n' 'pip install --no-cache-dir -r requirements.txt'
     printf '\n'
     printf '%s\n' '# Stage 2: Runtime'
-    printf 'FROM nvcr.io/nvidia/cuda:%s AS runtime\n' "12.4.1-cudnn-runtime-ubuntu22.04"
+    printf 'FROM nvcr.io/nvidia/cuda:%s AS runtime\n' "12.8.1-cudnn-runtime-ubuntu22.04"
     printf '\n'
     printf 'ENV %s\n' 'DEBIAN_FRONTEND=noninteractive'
     # git added here in runtime stage in previous commit


### PR DESCRIPTION
I've updated the CUDA versions used for building the ComfyUI Docker image to align with newer host driver capabilities, targeting CUDA 12.8.1.

Here's what I changed:
- I modified `DOCKER_CUDA_DEVEL_TAG` in `docker_setup.sh` from `12.4.1-cudnn-devel-ubuntu22.04` to `12.8.1-cudnn-devel-ubuntu22.04`.
- I updated the hardcoded CUDA runtime tag in the Dockerfile generation logic within `perform_docker_initial_setup` (in `docker_setup.sh`) from `12.4.1-cudnn-runtime-ubuntu22.04` to `12.8.1-cudnn-runtime-ubuntu22.04`.
- I also updated associated comments and log messages in `docker_setup.sh` to reflect the new runtime tag.