### PR TITLE
Feat: Add build-essential to Docker runtime stage

### DIFF
--- a/docker_setup.sh
+++ b/docker_setup.sh
@@ -189,7 +189,7 @@ perform_docker_initial_setup() {
     printf '\n'
     printf 'ENV %s\n' 'DEBIAN_FRONTEND=noninteractive'
     # git added here in runtime stage in previous commit
-    printf 'RUN %s\n' 'sed -i "s/http:\/\/archive.ubuntu.com\/ubuntu\//http:\/\/de.archive.ubuntu.com\/ubuntu\//g" /etc/apt/sources.list && sed -i "s/http:\/\/security.ubuntu.com\/ubuntu\//http:\/\/de.security.ubuntu.com\/ubuntu\//g" /etc/apt/sources.list && apt-get update && apt-get install -y --no-install-recommends git python3-pip ffmpeg curl libgl1 && rm -rf /var/lib/apt/lists/*'
+    printf 'RUN %s\n' 'sed -i "s/http:\/\/archive.ubuntu.com\/ubuntu\//http:\/\/de.archive.ubuntu.com\/ubuntu\//g" /etc/apt/sources.list && sed -i "s/http:\/\/security.ubuntu.com\/ubuntu\//http:\/\/de.security.ubuntu.com\/ubuntu\//g" /etc/apt/sources.list && apt-get update && apt-get install -y --no-install-recommends git python3-pip ffmpeg curl libgl1 build-essential && rm -rf /var/lib/apt/lists/*'
     printf 'COPY %s\n' '--from=builder /opt/venv /opt/venv'
     printf 'COPY %s\n' '--from=builder /app/ComfyUI /app/ComfyUI'
     printf 'WORKDIR %s\n' '/app/ComfyUI'


### PR DESCRIPTION
I've modified `docker_setup.sh` to include `build-essential` in the list of packages installed via `apt-get install` for the runtime stage of the generated Dockerfile.

This ensures that essential compilation tools (gcc, g++, make, etc.) are available in the runtime environment, complementing the CUDA devel image and aiding custom nodes that may need to compile components from source.