### PR TITLE
Feat: Add cache buster for runtime package installation in Docker

### DIFF
--- a/docker_setup.sh
+++ b/docker_setup.sh
@@ -88,6 +88,7 @@ build_comfyui_image() {
     # Execute docker build and tee output to log file and screen
     docker build -t "$COMFYUI_IMAGE_NAME" \
         --build-arg "$build_arg_devel_str" \
+        --build-arg "CACHE_BUSTER_RUNTIME_PACKAGES=$(date +%s)" \
         "$DOCKER_CONFIG_ACTUAL_PATH" 2>&1 | tee "${DOCKER_BUILD_LOG_FILE}"
 
     if [ ${PIPESTATUS[0]} -eq 0 ]; then
@@ -189,6 +190,7 @@ perform_docker_initial_setup() {
     printf '\n'
     printf 'ENV %s\n' 'DEBIAN_FRONTEND=noninteractive'
     # git added here in runtime stage in previous commit
+    printf 'ARG CACHE_BUSTER_RUNTIME_PACKAGES\n'
     printf 'RUN %s\n' 'sed -i "s/http:\/\/archive.ubuntu.com\/ubuntu\//http:\/\/de.archive.ubuntu.com\/ubuntu\//g" /etc/apt/sources.list && sed -i "s/http:\/\/security.ubuntu.com\/ubuntu\//http:\/\/de.security.ubuntu.com\/ubuntu\//g" /etc/apt/sources.list && apt-get update && apt-get install -y --no-install-recommends git python3-pip ffmpeg curl libgl1 build-essential && rm -rf /var/lib/apt/lists/*'
     printf 'COPY %s\n' '--from=builder /opt/venv /opt/venv'
     printf 'COPY %s\n' '--from=builder /app/ComfyUI /app/ComfyUI'


### PR DESCRIPTION
I've implemented a cache-busting mechanism for the runtime package installation step in the generated Dockerfile. This ensures that changes to the list of installed packages (like the recent addition of `build-essential`) are correctly applied during `docker build` instead of being skipped due to Docker's layer caching.

Changes:
- In `docker_setup.sh`, within `perform_docker_initial_setup`: An `ARG CACHE_BUSTER_RUNTIME_PACKAGES` instruction is now added to the Dockerfile before the `RUN apt-get install ...` line for the runtime stage.
- In `docker_setup.sh`, within `build_comfyui_image`: The `docker build` command now passes a build argument `--build-arg "CACHE_BUSTER_RUNTIME_PACKAGES=$(date +%s)"`. This sets the argument to the current timestamp, effectively invalidating the cache for this layer and subsequent layers on each build.