### PR TITLE
I've added `gcc` and `python3-dev` to the Dockerfile runtime packages.

### DIFF
--- a/docker_setup.sh
+++ b/docker_setup.sh
@@ -196,7 +196,7 @@ perform_docker_initial_setup() {
     printf 'ENV %s\n' 'DEBIAN_FRONTEND=noninteractive'
     # git added here in runtime stage in previous commit
     printf 'ARG CACHE_BUSTER_RUNTIME_PACKAGES\n'
-    printf 'RUN %s\n' 'sed -i "s/http:\/\/archive.ubuntu.com\/ubuntu\//http:\/\/de.archive.ubuntu.com\/ubuntu\//g" /etc/apt/sources.list && sed -i "s/http:\/\/security.ubuntu.com\/ubuntu\//http:\/\/de.security.ubuntu.com\/ubuntu\//g" /etc/apt/sources.list && apt-get update && apt-get install -y --no-install-recommends git python3-pip ffmpeg curl libgl1 build-essential && rm -rf /var/lib/apt/lists/*'
+    printf 'RUN %s\n' 'sed -i "s/http:\/\/archive.ubuntu.com\/ubuntu\//http:\/\/de.archive.ubuntu.com\/ubuntu\//g" /etc/apt/sources.list && sed -i "s/http:\/\/security.ubuntu.com\/ubuntu\//http:\/\/de.security.ubuntu.com\/ubuntu\//g" /etc/apt/sources.list && apt-get update && apt-get install -y --no-install-recommends git python3-pip ffmpeg curl libgl1 build-essential gcc python3-dev && rm -rf /var/lib/apt/lists/*'
     printf 'RUN ldconfig\n'
     printf 'COPY %s\n' '--from=builder /opt/venv /opt/venv'
     printf 'COPY %s\n' '--from=builder /app/ComfyUI /app/ComfyUI'


### PR DESCRIPTION
This updates `docker_setup.sh` to include `gcc` and `python3-dev` in the list of packages installed during the runtime stage of the generated Dockerfile.

These packages are often required for building Python extensions or other software dependencies within the container. `build-essential` was already present, and this adds these two commonly needed development packages.