### PR TITLE
Fix: Prevent Ctrl+C in log view from exiting main script

### DIFF
--- a/UltimateComfy.sh
+++ b/UltimateComfy.sh
@@ -147,7 +147,7 @@ view_autodownload_log() {
     echo "--- Viser logg (Ctrl+C for å avslutte) ---"
     # Ensure terminal is available for tail -f
     if [ -t 1 ] ; then
-        tail -f "$log_file_to_tail"
+        (tail -f "$log_file_to_tail")
     else
         log_error "Kan ikke kjøre 'tail -f': Ingen terminal tilgjengelig."
         log_error "Dette valget fungerer best når skriptet kjøres i et interaktivt terminalvindu."


### PR DESCRIPTION
This commit modifies the `view_autodownload_log` function in `UltimateComfy.sh`. The `tail -f` command is now run in a subshell e.g., `(tail -f ...)`.

This change is intended to improve signal handling, specifically to prevent pressing Ctrl+C while viewing the log from terminating the entire `UltimateComfy.sh` script. Instead, it should now only stop the `tail -f` command and return you to the menu.