### PR TITLE
Fix: Correct GPU allocation for multi-GPU Docker setups

### DIFF
--- a/docker_setup.sh
+++ b/docker_setup.sh
@@ -250,7 +250,7 @@ perform_docker_initial_setup() {
         host_port=$((8188 + i))
         echo "echo \"Starter ComfyUI for GPU $i (Container: $container_name) på port $host_port...\"" >> "$DOCKER_SCRIPTS_ACTUAL_PATH/start_comfyui.sh"
         echo "docker run -d --name \"$container_name\" \\" >> "$DOCKER_SCRIPTS_ACTUAL_PATH/start_comfyui.sh"
-        echo "  --gpus '\"device=$i\"' \\" >> "$DOCKER_SCRIPTS_ACTUAL_PATH/start_comfyui.sh"
+        echo "  --gpus device=$i \\" >> "$DOCKER_SCRIPTS_ACTUAL_PATH/start_comfyui.sh"
         echo "  -p \"${host_port}:8188\" \\" >> "$DOCKER_SCRIPTS_ACTUAL_PATH/start_comfyui.sh"
         echo "  -v \"$DOCKER_DATA_ACTUAL_PATH/models:/app/ComfyUI/models\" \\" >> "$DOCKER_SCRIPTS_ACTUAL_PATH/start_comfyui.sh"
         echo "  -v \"$DOCKER_DATA_ACTUAL_PATH/custom_nodes:/app/ComfyUI/custom_nodes\" \\" >> "$DOCKER_SCRIPTS_ACTUAL_PATH/start_comfyui.sh"


### PR DESCRIPTION
The `docker_setup.sh` script was generating an incorrect syntax for the `--gpus` flag in the `start_comfyui.sh` script. This resulted in Docker not assigning GPUs to containers as intended.

The problematic line generated:
`--gpus '"device=N"'`

This commit corrects the generation logic to produce the standard Docker syntax: `--gpus device=N`

This ensures that when multiple ComfyUI Docker containers are started, each is assigned to a distinct GPU as specified during the initial setup.