### PR TITLE
Fix: Ensure ComfyUI uses Docker-assigned GPU via --cuda-device

### DIFF
--- a/docker_setup.sh
+++ b/docker_setup.sh
@@ -263,7 +263,7 @@ perform_docker_initial_setup() {
         echo "  -v \"$DOCKER_DATA_ACTUAL_PATH/cache/gpu${i}/whisperx:/cache/whisperx\" \\" >> "$DOCKER_SCRIPTS_ACTUAL_PATH/start_comfyui.sh"
         echo "  --network host \\" >> "$DOCKER_SCRIPTS_ACTUAL_PATH/start_comfyui.sh" # Keep or remove based on user needs
         echo "  --restart unless-stopped \\" >> "$DOCKER_SCRIPTS_ACTUAL_PATH/start_comfyui.sh"
-        echo "  \"$COMFYUI_IMAGE_NAME\" python3 main.py --max-upload-size 1000 --listen 0.0.0.0 --port \"${host_port}\" --preview-method auto" >> "$DOCKER_SCRIPTS_ACTUAL_PATH/start_comfyui.sh"
+        echo "  \"$COMFYUI_IMAGE_NAME\" python3 main.py --max-upload-size 1000 --listen 0.0.0.0 --port \"${host_port}\" --preview-method auto --cuda-device $i" >> "$DOCKER_SCRIPTS_ACTUAL_PATH/start_comfyui.sh"
         echo "echo \"ComfyUI for GPU $i (Container: $container_name) er tilgjengelig på http://localhost:${host_port}\"" >> "$DOCKER_SCRIPTS_ACTUAL_PATH/start_comfyui.sh"
     done
     chmod +x "$DOCKER_SCRIPTS_ACTUAL_PATH/start_comfyui.sh"


### PR DESCRIPTION
This commit builds upon the previous fix for GPU allocation in multi-GPU Docker setups.

While the `--gpus device=N` flag correctly assigns a GPU to the Docker container, ComfyUI itself also needs to be directed to use that specific GPU. This is achieved by adding the `--cuda-device N` flag to the `python3 main.py` command.

The `docker_setup.sh` script has been updated to include this flag dynamically based on the GPU index when generating the `start_comfyui.sh` script.

This ensures that ComfyUI instances running in separate Docker containers not only have a GPU assigned at the Docker level but also internally utilize the correct GPU, preventing conflicts and ensuring proper resource allocation on multi-GPU systems.