### PR TITLE
This commit resolves multiple issues with the Docker build process.

### DIFF
--- a/docker_setup.sh
+++ b/docker_setup.sh
@@ -54,6 +54,13 @@ check_docker_status() {
 
 build_comfyui_image() {
     script_log "DEBUG: ENTERING build_comfyui_image (docker_setup.sh)"
+
+    if ! check_and_perform_nvcr_login; then
+        log_error "NVIDIA Container Registry login failed or was skipped. Aborting build."
+        script_log "DEBUG: EXITING build_comfyui_image (nvcr login failed)"
+        return 1
+    fi
+
     # initialize_docker_paths # This should be called before this function if paths are needed immediately.
                             # Or ensure it's called if DOCKER_CONFIG_ACTUAL_PATH is empty.
     if [[ -z "$DOCKER_CONFIG_ACTUAL_PATH" ]]; then


### PR DESCRIPTION
1. Removes hardcoded German Ubuntu mirrors from the Dockerfile generation in `docker_setup.sh`. This fixes build failures caused by DNS resolution errors for `de.archive.ubuntu.com`.

2. Adds a new function, `check_and_perform_nvcr_login`, to `common_utils.sh`. This function checks if the user is logged into `nvcr.io` before a build is attempted.

3. If not logged in, the script now securely prompts the user for their NVIDIA NGC API key and uses it to perform a non-interactive login. This avoids `401 Unauthorized` errors when pulling the base CUDA image.

This makes the entire setup and build process more robust and user-friendly.