### PR TITLE
Fix multi-GPU startup and add frontend update option

### DIFF
--- a/UltimateComfy.sh
+++ b/UltimateComfy.sh
@@ -189,7 +189,7 @@ main_menu() {
 Image: $COMFYUI_IMAGE_NAME
 
 Choose an option:" \
-                22 76 10 \
+                22 76 11 \
                 "1" "Førstegangs oppsett/Installer ComfyUI i Docker" \
                 "2" "Bygg/Oppdater ComfyUI Docker Image" \
                 "3" "Last ned/Administrer Modeller" \
@@ -199,14 +199,15 @@ Choose an option:" \
                 "7" "Update UltimateComfy" \
                 "8" "Oppgrader NVIDIA Driver (Host)" \
                 "9" "Se Auto-Download Service Logg" \
-                "10" "Avslutt" \
+                "10" "Update Frontend" \
+                "11" "Avslutt" \
                 2>/dev/tty)
 
             local dialog_exit_status=$?
             script_log "DEBUG: dialog command finished. main_choice='$main_choice', dialog_exit_status='$dialog_exit_status'"
             if [ $dialog_exit_status -ne 0 ]; then
-                main_choice="10" # Updated for new Avslutt number
-                script_log "DEBUG: Dialog cancelled or Exit selected, main_choice set to 10."
+                main_choice="11" # Updated for new Avslutt number
+                script_log "DEBUG: Dialog cancelled or Exit selected, main_choice set to 11."
             fi
         else
             script_log "DEBUG: Using basic menu fallback."
@@ -225,9 +226,10 @@ Choose an option:" \
             echo "7) Update UltimateComfy"
             echo "8) Oppgrader NVIDIA Driver (Host)"
             echo "9) Se Auto-Download Service Logg"
-            echo "10) Avslutt"
+            echo "10) Update Frontend"
+            echo "11) Avslutt"
             echo "--------------------------------"
-            echo -n "Velg et alternativ (1-10): " >&2
+            echo -n "Velg et alternativ (1-11): " >&2
             read -r main_choice </dev/tty
             script_log "DEBUG: Basic menu read finished. main_choice='$main_choice'"
         fi
@@ -326,7 +328,18 @@ Choose an option:" \
                 press_enter_to_continue
                 ;;
             "10")
-                script_log "DEBUG: main_menu attempting to exit (Option 10)."
+                script_log "INFO: User selected 'Update Frontend'."
+                local update_frontend_script_path
+                update_frontend_script_path="$(dirname "$0")/update_frontend.sh"
+                if [ -x "$update_frontend_script_path" ]; then
+                    "$update_frontend_script_path"
+                else
+                    log_error "Update frontend script not found or not executable at $update_frontend_script_path."
+                fi
+                press_enter_to_continue
+                ;;
+            "11")
+                script_log "DEBUG: main_menu attempting to exit (Option 11)."
                 log_info "Avslutter." # from common_utils.sh
                 clear
                 exit 0
@@ -336,7 +349,7 @@ Choose an option:" \
                     # dialog is from common_utils.sh (via ensure_dialog_installed)
                     dialog --title "Ugyldig valg" --msgbox "Vennligst velg et gyldig alternativ fra menyen." 6 50 2>/dev/tty
                 else
-                    log_warn "Ugyldig valg. Skriv inn et tall fra 1-10." # from common_utils.sh
+                    log_warn "Ugyldig valg. Skriv inn et tall fra 1-11." # from common_utils.sh
                 fi
                 press_enter_to_continue # from common_utils.sh
                 ;;

--- a/docker_setup.sh
+++ b/docker_setup.sh
@@ -279,7 +279,7 @@ perform_docker_initial_setup() {
         echo "  -v \"$DOCKER_DATA_ACTUAL_PATH/cache/gpu${i}/whisperx:/cache/whisperx\" \\" >> "$DOCKER_SCRIPTS_ACTUAL_PATH/start_comfyui.sh"
         echo "  --network host \\" >> "$DOCKER_SCRIPTS_ACTUAL_PATH/start_comfyui.sh" # Keep or remove based on user needs
         echo "  --restart unless-stopped \\" >> "$DOCKER_SCRIPTS_ACTUAL_PATH/start_comfyui.sh"
-        echo "  \"$COMFYUI_IMAGE_NAME\" python3 main.py --max-upload-size 1000 --listen 0.0.0.0 --port \"${host_port}\" --preview-method auto --cuda-device $i" >> "$DOCKER_SCRIPTS_ACTUAL_PATH/start_comfyui.sh"
+        echo "  \"$COMFYUI_IMAGE_NAME\" python3 main.py --max-upload-size 1000 --listen 0.0.0.0 --port \"${host_port}\" --preview-method auto --cuda-device 0" >> "$DOCKER_SCRIPTS_ACTUAL_PATH/start_comfyui.sh"
         echo "echo \"ComfyUI for GPU $i (Container: $container_name) er tilgjengelig på http://localhost:${host_port}\"" >> "$DOCKER_SCRIPTS_ACTUAL_PATH/start_comfyui.sh"
     done
     chmod +x "$DOCKER_SCRIPTS_ACTUAL_PATH/start_comfyui.sh"

--- a/update_frontend.sh
+++ b/update_frontend.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+# Source common utilities
+# Assuming common_utils.sh is in the same directory
+# shellcheck source=./common_utils.sh
+source "$(dirname "$0")/common_utils.sh" || { echo "ERROR: common_utils.sh not found or failed to source."; exit 1; }
+
+script_log "INFO: update_frontend.sh started."
+
+if ! check_docker_status; then
+    log_error "Docker is not running. Please start Docker and try again."
+    script_log "INFO: update_frontend.sh finished (Docker not running)."
+    exit 1
+fi
+
+log_info "Searching for running ComfyUI containers (comfyui-gpu*)..."
+mapfile -t running_containers < <(docker ps --filter "name=comfyui-gpu" --format "{{.Names}}")
+
+if [ ${#running_containers[@]} -eq 0 ]; then
+    log_warn "No running ComfyUI containers found."
+    script_log "INFO: update_frontend.sh finished (no containers found)."
+    exit 0
+fi
+
+log_info "Found running containers:"
+for container in "${running_containers[@]}"; do
+    echo " - $container"
+done
+
+for container in "${running_containers[@]}"; do
+    log_info "--- Updating frontend for $container ---"
+
+    # The command to run inside the container
+    update_command="/opt/venv/bin/python3 -m pip install -r /app/ComfyUI/requirements.txt"
+
+    log_info "Executing command in $container: $update_command"
+
+    # Execute the command
+    docker exec "$container" sh -c "$update_command"
+
+    if [ $? -eq 0 ]; then
+        log_success "--- Successfully updated frontend for $container ---"
+    else
+        log_error "--- Failed to update frontend for $container ---"
+    fi
+done
+
+log_success "Frontend update process finished for all found containers."
+script_log "INFO: update_frontend.sh finished."
+exit 0


### PR DESCRIPTION
- Modified `docker_setup.sh` to correctly assign CUDA devices to containers. The `--cuda-device` flag is now always set to `0`, as Docker's `--gpus` flag handles mapping the correct host GPU to `cuda:0` inside the container. This resolves the "No CUDA GPUs are available" error for the second GPU instance.

- Added a new script `update_frontend.sh` to update the ComfyUI frontend by running `pip install -r requirements.txt` inside all running `comfyui-gpu*` containers.

- Added a new "Update Frontend" option to the main menu in `UltimateComfy.sh` to execute the new script.