### PR TITLE
Fix missing import in update_frontend.sh

### DIFF
--- a/update_frontend.sh
+++ b/update_frontend.sh
@@ -4,6 +4,8 @@
 # Assuming common_utils.sh is in the same directory
 # shellcheck source=./common_utils.sh
 source "$(dirname "$0")/common_utils.sh" || { echo "ERROR: common_utils.sh not found or failed to source."; exit 1; }
+# shellcheck source=./docker_setup.sh
+source "$(dirname "$0")/docker_setup.sh" || { echo "ERROR: docker_setup.sh not found or failed to source. Exiting."; exit 1; }
 
 script_log "INFO: update_frontend.sh started."
 


### PR DESCRIPTION
The `update_frontend.sh` script was failing with a "command not found" error because it was trying to call the `check_docker_status` function without importing the script that defines it.

This change adds the necessary `source` command to import `docker_setup.sh`, which contains the `check_docker_status` function.