### PR TITLE
feat: Add menu option to install and run ncdu

### DIFF
--- a/UltimateComfy.sh
+++ b/UltimateComfy.sh
@@ -189,7 +189,7 @@ main_menu() {
 Image: $COMFYUI_IMAGE_NAME
 
 Choose an option:" \
-                22 76 11 \
+                23 76 12 \
                 "1" "Førstegangs oppsett/Installer ComfyUI i Docker" \
                 "2" "Bygg/Oppdater ComfyUI Docker Image" \
                 "3" "Last ned/Administrer Modeller" \
@@ -200,14 +200,15 @@ Choose an option:" \
                 "8" "Oppgrader NVIDIA Driver (Host)" \
                 "9" "Se Auto-Download Service Logg" \
                 "10" "Update Frontend" \
-                "11" "Avslutt" \
+                "11" "Installer og kjør ncdu" \
+                "12" "Avslutt" \
                 2>/dev/tty)
 
             local dialog_exit_status=$?
             script_log "DEBUG: dialog command finished. main_choice='$main_choice', dialog_exit_status='$dialog_exit_status'"
             if [ $dialog_exit_status -ne 0 ]; then
-                main_choice="11" # Updated for new Avslutt number
-                script_log "DEBUG: Dialog cancelled or Exit selected, main_choice set to 11."
+                main_choice="12" # Updated for new Avslutt number
+                script_log "DEBUG: Dialog cancelled or Exit selected, main_choice set to 12."
             fi
         else
             script_log "DEBUG: Using basic menu fallback."
@@ -227,9 +228,10 @@ Choose an option:" \
             echo "8) Oppgrader NVIDIA Driver (Host)"
             echo "9) Se Auto-Download Service Logg"
             echo "10) Update Frontend"
-            echo "11) Avslutt"
+            echo "11) Installer og kjør ncdu"
+            echo "12) Avslutt"
             echo "--------------------------------"
-            echo -n "Velg et alternativ (1-11): " >&2
+            echo -n "Velg et alternativ (1-12): " >&2
             read -r main_choice </dev/tty
             script_log "DEBUG: Basic menu read finished. main_choice='$main_choice'"
         fi
@@ -339,7 +341,23 @@ Choose an option:" \
                 press_enter_to_continue
                 ;;
             "11")
-                script_log "DEBUG: main_menu attempting to exit (Option 11)."
+                script_log "INFO: User selected 'Installer og kjør ncdu'."
+                local ncdu_script_path
+                ncdu_script_path="$(dirname "$0")/run_ncdu.sh"
+                if [ -f "$ncdu_script_path" ]; then
+                    if [ -x "$ncdu_script_path" ]; then
+                        "$ncdu_script_path"
+                    else
+                        log_error "FEIL: $ncdu_script_path er ikke kjørbar (executable)."
+                        log_error "Kjør 'chmod +x $ncdu_script_path' for å fikse."
+                    fi
+                else
+                    log_error "FEIL: $ncdu_script_path ble ikke funnet."
+                fi
+                press_enter_to_continue
+                ;;
+            "12")
+                script_log "DEBUG: main_menu attempting to exit (Option 12)."
                 log_info "Avslutter." # from common_utils.sh
                 clear
                 exit 0
@@ -349,7 +367,7 @@ Choose an option:" \
                     # dialog is from common_utils.sh (via ensure_dialog_installed)
                     dialog --title "Ugyldig valg" --msgbox "Vennligst velg et gyldig alternativ fra menyen." 6 50 2>/dev/tty
                 else
-                    log_warn "Ugyldig valg. Skriv inn et tall fra 1-11." # from common_utils.sh
+                    log_warn "Ugyldig valg. Skriv inn et tall fra 1-12." # from common_utils.sh
                 fi
                 press_enter_to_continue # from common_utils.sh
                 ;;

--- a/run_ncdu.sh
+++ b/run_ncdu.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+# Source common utilities
+# shellcheck source=./common_utils.sh
+source "$(dirname "$0")/common_utils.sh" || { echo "ERROR: common_utils.sh not found. Exiting."; exit 1; }
+
+# --- NCDU Installer and Runner ---
+run_ncdu() {
+    log_info "Starter ncdu-installasjon og kjøring..."
+
+    # Sjekk for sudo/root-tilgang
+    if [[ $EUID -ne 0 ]]; then
+        log_info "Dette skriptet krever sudo-rettigheter for å installere pakker og skanne disken."
+        log_info "Du kan bli bedt om passordet ditt."
+        # Kjører en tom sudo kommando for å trigge passord-prompt tidlig
+        sudo -v
+        if [ $? -ne 0 ]; then
+            log_error "Klarte ikke å få sudo-rettigheter. Avbryter."
+            return 1
+        fi
+    fi
+
+    log_info "Oppdaterer pakkedatabasen (sudo apt update)..."
+    if sudo apt-get update; then
+        log_info "Pakkedatabasen ble oppdatert."
+    else
+        log_error "Klarte ikke å oppdatere pakkedatabasen. Sjekk internettforbindelsen din og prøv igjen."
+        return 1
+    fi
+
+    log_info "Installerer ncdu (sudo apt install ncdu)..."
+    if sudo apt-get install -y ncdu; then
+        log_info "ncdu ble installert."
+    else
+        log_error "Klarte ikke å installere ncdu. Prøv å kjøre installasjonen manuelt."
+        return 1
+    fi
+
+    log_info "Starter ncdu for å analysere diskbruk fra roten (/)..."
+    log_info "Trykk 'q' for å avslutte ncdu når du er ferdig."
+    echo "----------------------------------------------------"
+    echo " Starter ncdu... (laster inn diskdata)"
+    echo "----------------------------------------------------"
+
+    # Kjør ncdu
+    if sudo ncdu /; then
+        log_info "ncdu-sesjonen ble avsluttet normalt."
+    else
+        log_error "ncdu-sesjonen ble avsluttet med en feil."
+    fi
+
+    echo "----------------------------------------------------"
+    log_info "Tilbake til hovedmenyen."
+}
+
+# Kjør hovedfunksjonen hvis skriptet kjøres direkte
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    run_ncdu
+    # Gi brukeren tid til å lese output før skjermen eventuelt tømmes av hovedskriptet
+    press_enter_to_continue
+fi


### PR DESCRIPTION
This commit introduces a new menu option in `UltimateComfy.sh` to install and run `ncdu`, a disk usage analyzer.

The new menu option is "Installer og kjør ncdu". When selected, it executes a new script `run_ncdu.sh` which:
1. Updates package lists with `sudo apt update`.
2. Installs `ncdu` with `sudo apt install -y ncdu`.
3. Runs `ncdu` on the root directory with `sudo ncdu /`.

This provides a convenient way for users to analyze disk usage directly from the main script.