### PR TITLE
fix: Handle held packages during NVIDIA driver purge

### DIFF
--- a/upgrade_nvidia_driver.sh
+++ b/upgrade_nvidia_driver.sh
@@ -170,7 +170,7 @@ fi
 read -r -p "For å unngå konflikter, anbefales det å fjerne alle eksisterende NVIDIA-driverpakker først. Dette kan løse 'unmet dependencies'-feil. Vil du gjøre dette? (Y/n): " purge_choice
 if [[ ! "$purge_choice" =~ ^[Nn]$ ]]; then
     log_info "Fjerner eksisterende NVIDIA-pakker for å unngå konflikter..."
-    if ! apt-get purge -y 'nvidia-*' 'libnvidia-*'; then
+    if ! apt-get purge -y --allow-change-held-packages 'nvidia-*' 'libnvidia-*'; then
         log_error "Klarte ikke å fjerne eksisterende NVIDIA-pakker. Dette kan føre til problemer."
         log_warn "Prøver å fortsette uansett, men installasjonen kan mislykkes."
     else


### PR DESCRIPTION
Adds the `--allow-change-held-packages` flag to the `apt-get purge` command in the `upgrade_nvidia_driver.sh` script.

This is necessary to ensure that the pre-installation cleanup step can successfully remove all old NVIDIA packages, including those that have been marked as "held" by the package manager. This resolves the error `E: Held packages were changed and -y was used without --allow-change-held-packages.` that was preventing the script from working correctly.