### PR TITLE
feat: Add Windows compatibility

### DIFF
--- a/UltimateComfy.bat
+++ b/UltimateComfy.bat
@@ -1,0 +1,49 @@
+@echo off
+setlocal
+
+:: Check if we are running in a Git Bash (MinTTY) environment.
+:: The "TERM" variable is a good indicator. In cmd.exe it's typically not set.
+:: In Git Bash, it's often "cygwin" or "xterm".
+if "%TERM%" == "cygwin" goto :run_script
+if "%TERM%" == "xterm" goto :run_script
+
+:: If not in Git Bash, find bash.exe and re-launch.
+echo Not running in Git Bash. Attempting to launch Git Bash...
+
+set "GIT_BASH_PATH="
+if exist "%ProgramFiles%\Git\bin\bash.exe" set "GIT_BASH_PATH=%ProgramFiles%\Git\bin\bash.exe"
+if exist "%ProgramFiles(x86)%\Git\bin\bash.exe" set "GIT_BASH_PATH=%ProgramFiles(x86)%\Git\bin\bash.exe"
+if exist "%LOCALAPPDATA%\Programs\Git\bin\bash.exe" set "GIT_BASH_PATH=%LOCALAPPDATA%\Programs\Git\bin\bash.exe"
+
+if not defined GIT_BASH_PATH (
+    echo.
+    echo ERROR: Git Bash (bash.exe) not found in common locations.
+    echo Please install Git for Windows and ensure it's in your PATH or installed in the default directory.
+    echo You can also run this script from a Git Bash terminal directly.
+    pause
+    exit /b 1
+)
+
+echo Found Git Bash at: %GIT_BASH_PATH%
+echo Launching UltimateComfy.sh...
+echo.
+
+:: Execute the .sh script using the found bash.exe.
+:: We pass the path to the .sh script. %~dp0 expands to the directory of the batch file.
+"%GIT_BASH_PATH%" --login -i "%~dp0UltimateComfy.sh"
+
+:: Pause at the end to see any final messages from the script if it exits quickly.
+echo.
+echo Script execution finished. Press any key to exit this window.
+pause
+goto :eof
+
+:run_script
+echo Already in a Git Bash environment. Running script directly.
+bash "%~dp0/UltimateComfy.sh"
+echo.
+echo Script execution finished.
+:: No pause here, as the user is already in a shell.
+
+:eof
+endlocal

--- a/model_downloader.sh
+++ b/model_downloader.sh
@@ -23,7 +23,15 @@ md_check_jq() {
     script_log "DEBUG: ENTERING md_check_jq (model_downloader.sh)"
     if ! command -v jq &> /dev/null; then
         log_error "'jq' er ikke funnet. Dette kreves for modelldenedlasting."
-        log_error "Installer med: sudo apt update && sudo apt install jq"
+        # OS_TYPE is sourced from common_utils.sh in the main script
+        if [[ "$OS_TYPE" == "linux" ]]; then
+            log_error "Installer med: sudo apt update && sudo apt install jq"
+        elif [[ "$OS_TYPE" == "windows" ]]; then
+            log_error "Installer 'jq' for Windows. For eksempel med Chocolatey: choco install jq"
+            log_error "Eller last ned fra: https://jqlang.github.io/jq/download/"
+        else
+            log_error "Vennligst installer 'jq' for ditt operativsystem."
+        fi
         script_log "DEBUG: EXITING md_check_jq (jq not found)"
         return 1
     fi
@@ -89,6 +97,10 @@ md_find_and_select_comfyui_path() {
         fi
     done
     local search_locations=("$HOME" "/mnt" "/opt" "/srv")
+    if [[ "$OS_TYPE" == "windows" ]]; then
+        # Add common drive letters for Windows environments (as seen by Git Bash)
+        search_locations+=("/c/" "/d/")
+    fi
     if [[ -n "${BASE_DOCKER_SETUP_DIR:-}" && -d "$BASE_DOCKER_SETUP_DIR" ]]; then
         search_locations+=("$BASE_DOCKER_SETUP_DIR")
     fi


### PR DESCRIPTION
This commit introduces Windows support for the UltimateComfy script suite.

Key changes:
- A new `UltimateComfy.bat` script is added as an entry point for Windows users. It automatically launches the main script in a Git Bash environment.
- The shell scripts (`common_utils.sh`, `docker_setup.sh`, `model_downloader.sh`) have been made platform-aware. They now detect the OS and adjust their behavior for things like dependency checks, Docker commands, and file path searching.
- The `--network host` Docker option has been removed from the generated start scripts to ensure compatibility with Docker Desktop on Windows and macOS. The scripts now use standard port mapping.
- The `README.md` file has been updated with detailed instructions for Windows users and reflects the networking changes.