### PR TITLE
Fix(docker): Add robust OS detection for Windows path conversion

### DIFF
--- a/common_utils.sh
+++ b/common_utils.sh
@@ -3,12 +3,18 @@
 # --- Globale Innstillinger og Konstanter ---
 # OS Detection
 OS_TYPE="unknown"
-case "$(uname -s)" in
-    Linux*)     OS_TYPE="linux";;
-    Darwin*)    OS_TYPE="mac";;
-    CYGWIN*|MINGW*|MSYS*) OS_TYPE="windows";;
-    *)          OS_TYPE="unknown";;
-esac
+# First, check for the OS environment variable, which is common in Git Bash on Windows.
+if [ -n "$OS" ] && [ "$OS" == "Windows_NT" ]; then
+    OS_TYPE="windows"
+else
+    # Fallback to uname, which is the standard way.
+    case "$(uname -s)" in
+        Linux*)     OS_TYPE="linux";;
+        Darwin*)    OS_TYPE="mac";;
+        CYGWIN*|MINGW*|MSYS*) OS_TYPE="windows";;
+        *)          OS_TYPE="unknown";;
+    esac
+fi
 
 # Farger for logging
 RED='[0;31m'


### PR DESCRIPTION
This commit implements a comprehensive fix for Docker volume mounting on Windows by addressing the root cause, which was a failure to detect the OS correctly.

The script's `uname -s` check was not sufficient to identify the user's Windows environment, causing the path conversion logic to be skipped. This commit improves the OS detection in `common_utils.sh` by first checking for the `Windows_NT` value in the `$OS` environment variable, which is a reliable indicator in Git Bash, before falling back to `uname`.

This ensures that the OS is correctly identified as Windows, allowing the `cygpath` conversion in `docker_setup.sh` to execute as intended. This will generate the correct path format (`C:/Users/...`) in the startup script, resolving the volume mounting failures.